### PR TITLE
first_match is deprecated as of webob >= 1.1b1 and fails with current webob version (1.2b2) from pypi

### DIFF
--- a/wsgiservice/resource.py
+++ b/wsgiservice/resource.py
@@ -207,7 +207,7 @@ class Resource(object):
         else:
             self.response.vary.append('Accept')
         types = [mime for ext, mime in self.EXTENSION_MAP]
-        return self.request.accept.first_match(types)
+        return self.request.accept.best_match(types)
 
     def handle_ignored_resources(self):
         """Ignore robots.txt and favicon.ico GET requests based on a list of


### PR DESCRIPTION
Signed-off-by: Steven Armstrong steven.armstrong@inf.ethz.ch
