### PR TITLE
Added a versioning decorator

### DIFF
--- a/wsgiservice/__init__.py
+++ b/wsgiservice/__init__.py
@@ -5,7 +5,7 @@ applications.
 __version__ = "0.4.0"
 
 from application import get_app
-from decorators import mount, validate, expires
+from decorators import mount, validate, expires, versions
 import exceptions
 from resource import Resource
 import routing

--- a/wsgiservice/decorators.py
+++ b/wsgiservice/decorators.py
@@ -4,6 +4,16 @@ from datetime import timedelta
 from webob import timedelta_to_seconds
 
 
+def versions(versions, default=False):
+    def wrap(cls):
+        prefixes = map(lambda v: 'v' + str(v), versions)
+        if default:
+            prefixes += [cls.DEFAULT_PREFIX,]
+        cls._prefixes = prefixes
+        return cls
+    return wrap
+
+
 def mount(path):
     """Decorator. Apply on a :class:`wsgiservice.Resource` to mount it at the
     given path. The same can be achieved by setting the ``_path`` attribute on

--- a/wsgiservice/resource.py
+++ b/wsgiservice/resource.py
@@ -80,6 +80,8 @@ class Resource(object):
     # Cache for the `data` property
     _data = None
 
+    DEFAULT_PREFIX = ''
+
     def __init__(self, request, response, path_params, application=None):
         """Constructor. Order of the parameters is not guaranteed, always
         used named parameters.

--- a/wsgiservice/routing.py
+++ b/wsgiservice/routing.py
@@ -49,7 +49,7 @@ class Router(object):
         search_vars = re.compile(r'\{(\w+)\}').finditer
         for resource in resources:
             # Compile regular expression for each path
-            path, regexp, prev_pos = resource._path, '^', 0
+            path, regexp, prev_pos = resource._path, '', 0
             for match in search_vars(path):
                 regexp += re.escape(path[prev_pos:match.start()])
                 # .+? - match any character but non-greedy
@@ -59,6 +59,10 @@ class Router(object):
             # Allow an extension to overwrite the mime type
             extensions = "|".join([ext for ext, _ in resource.EXTENSION_MAP])
             regexp += '(?P<_extension>' + extensions + ')?$'
+            if hasattr(resource, '_prefixes'):
+                prefixes = '|'.join([p for p in resource._prefixes if p != resource.DEFAULT_PREFIX])
+                prefix_check = '?' if resource.DEFAULT_PREFIX in resource._prefixes else ''
+                regexp = '^(/(?P<prefix>' + prefixes + '))' + prefix_check + regexp
             routes.append((re.compile(regexp).match, resource))
         return routes
 


### PR DESCRIPTION
Not much documented.
We added a versioning decorator which work like this :

@versions([1, 2], default=True)
@mount('/test/')
class Test(Resource):
    ...

This way, the Test resource will be reachable via '/v1/test/', '/v2/test/' or '/test/' as default is set to True.
Tell us if you like the idea !